### PR TITLE
Fix: set wrong variable

### DIFF
--- a/src/libcec/devices/CECBusDevice.cpp
+++ b/src/libcec/devices/CECBusDevice.cpp
@@ -1506,7 +1506,7 @@ bool CCECBusDevice::TransmitMuteAudio(const cec_logical_address source)
 
 void CCECBusDevice::SetActiveSourceSent(bool setto /* = true */)
 {
-  m_bActiveSource = setto;
+  m_bActiveSourceSent = setto;
 }
 
 bool CCECBusDevice::ActiveSourceSent(void) const


### PR DESCRIPTION
This fixes many cec reconnect problems, in my case if tv is turned on again.

Should also fix: #343 #342